### PR TITLE
fix(pubmed): 避免抓到 ReferenceList 內引用文獻的 DOI

### DIFF
--- a/src/zotero_arxiv_daily/retriever/pubmed_retriever.py
+++ b/src/zotero_arxiv_daily/retriever/pubmed_retriever.py
@@ -93,9 +93,15 @@ class PubmedRetriever(BaseRetriever):
                 # PMID 與 DOI
                 pmid = medline.findtext("PMID", "")
                 doi = ""
-                for id_node in article.findall(".//ArticleId"):
+                # 只抓文章本身的 DOI，避免誤抓 ReferenceList 內引用文獻的 DOI
+                for id_node in article.findall("./PubmedData/ArticleIdList/ArticleId"):
                     if id_node.get("IdType") == "doi":
                         doi = id_node.text or ""
+                        break
+                if not doi:
+                    elocation = art.find("./ELocationID[@EIdType='doi']")
+                    if elocation is not None:
+                        doi = (elocation.text or "").strip()
                 papers.append({
                     "title": title,
                     "abstract": abstract,


### PR DESCRIPTION
## Summary

PubMed retriever 的 DOI 解析邏輯以 `.//ArticleId` 遞迴搜尋整個 `PubmedArticle`,會誤抓 `<ReferenceList>/<Reference>/<ArticleIdList>/<ArticleId>` 內引用文獻的 DOI,導致 `pdf_url` 指向完全不相關的舊論文。

## Root cause

`article.findall(\".//ArticleId\")` 命中:
1. `./PubmedData/ArticleIdList/ArticleId` (文章本身,正確)
2. `./ReferenceList/Reference/ArticleIdList/ArticleId` (引用文獻,錯誤)

迴圈無 `break`,最後被引用文獻的 DOI 覆寫。

## Fix

- 限縮 XPath 至 `./PubmedData/ArticleIdList/ArticleId`
- 命中後 `break`
- Fallback 到 `MedlineCitation/Article/ELocationID[@EIdType='doi']`

## Evidence

mail_20260417.txt 中「Extrapolated Persian Lexical Affect Norms (E-PLAN) ... (2026)」的 PDF 連結指向 `https://doi.org/10.1016/j.paid.2004.09.017` (2004 PAID 論文),與目標文章無關。

## Test plan

- [ ] Workflow run 後檢查次日 mail 的 pubmed 區塊 PDF 連結是否指向正確 DOI
- [ ] 確認 PMID landing page fallback 仍可用 (DOI 抓不到時)

🤖 Generated with [Claude Code](https://claude.com/claude-code)