### PR TITLE
chore: auto-add issues/PRs to CSC PKM project

### DIFF
--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -1,0 +1,16 @@
+name: Add to Project
+
+on:
+  issues:
+    types: [opened, reopened]
+  pull_request:
+    types: [opened, reopened]
+
+jobs:
+  add-to-project:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/add-to-project@v1
+        with:
+          project-url: https://github.com/users/SCgeeker/projects/1
+          github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}


### PR DESCRIPTION
## Summary

新 workflow 將新開/reopen 的 issue 與 PR 自動加入 GitHub Project #1 (CSC PKM system)。

## Merge 前置作業

需在 repo 建立 secret `ADD_TO_PROJECT_PAT`:

1. 於 https://github.com/settings/tokens 建立 Classic PAT,scopes 勾選:
   - \`project\`
   - \`repo\`
2. 存入 secret:
   \`\`\`bash
   gh secret set ADD_TO_PROJECT_PAT --repo SCgeeker/zotero-arxiv-daily
   \`\`\`

未設 secret 時 workflow 會失敗但不影響其他功能。

## Test plan

- [ ] 設 PAT secret
- [ ] Merge 後開一個 test issue,確認 30 秒內出現在 project
- [ ] Test issue 關掉

🤖 Generated with [Claude Code](https://claude.com/claude-code)